### PR TITLE
增加判断游戏启动失败的逻辑

### DIFF
--- a/assets/game_data/screen_info/enter_game.yml
+++ b/assets/game_data/screen_info/enter_game.yml
@@ -158,3 +158,29 @@ area_list:
   template_id: ''
   template_match_threshold: 0.7
   goto_list: []
+- area_name: 提示-确认
+  id_mark: false
+  pc_rect:
+  - 948
+  - 649
+  - 1007
+  - 693
+  text: 确认
+  lcs_percent: 0.5
+  template_sub_dir: ''
+  template_id: ''
+  template_match_threshold: 0.7
+  goto_list: []
+- area_name: 错误提示-重新启动
+  id_mark: false
+  pc_rect:
+  - 1133
+  - 708
+  - 1230
+  - 754
+  text: 重新启动
+  lcs_percent: 0.5
+  template_sub_dir: ''
+  template_id: ''
+  template_match_threshold: 0.7
+  goto_list: []


### PR DESCRIPTION
若点击到“重新启动”，则可认为检查到“获取全局分发错误”，是用户网络设置问题（VPN、加速器或者完全没联网），中止运行。
若点击到“确认”，则可认为检查到“错误代码”，是网络连接不稳定，继续重试启动。
暂未出现其他登录失败情况。