### PR TITLE
新增 奇巧零食 是否自动合成选项

### DIFF
--- a/src/sr_od/app/trick_snack/trick_snack_app.py
+++ b/src/sr_od/app/trick_snack/trick_snack_app.py
@@ -33,6 +33,9 @@ class TrickSnackApp(SrApplication):
     @node_from(from_name='购买路线2')
     @operation_node(name='合成')
     def synthesize_trick_snack(self) -> OperationRoundResult:
+        if not self.ctx.trick_snack_config.synthesize_trick_snack:
+            return self.round_success('合成功能未启用')
+
         op = CustomCombineOp(self.ctx, 'synthesize_trick_snack', no_battle=True)
         return self.round_by_op_result(op.execute())
 

--- a/src/sr_od/app/trick_snack/trick_snack_config.py
+++ b/src/sr_od/app/trick_snack/trick_snack_config.py
@@ -24,3 +24,11 @@ class TrickSnackConfig(YamlConfig):
     @route_xzlf_xchzs.setter
     def route_xzlf_xchzs(self, new_value: bool) -> None:
         self.update('route_xzlf_xchzs', new_value)
+
+    @property
+    def synthesize_trick_snack(self) -> bool:
+        return self.get('synthesize_trick_snack', True)
+
+    @synthesize_trick_snack.setter
+    def synthesize_trick_snack(self, new_value: bool) -> None:
+        self.update('synthesize_trick_snack', new_value)

--- a/src/sr_od/gui/interface/one_dragon/sr_od_setting_interface.py
+++ b/src/sr_od/gui/interface/one_dragon/sr_od_setting_interface.py
@@ -52,6 +52,9 @@ class SrOdSettingInterface(VerticalScrollInterface):
         self.route_xzlf_xchzs_opt = SwitchSettingCard(icon=FluentIcon.GAME, title='仙舟「罗浮」 星槎海中枢 货全')
         group.addSettingCard(self.route_xzlf_xchzs_opt)
 
+        self.synthesize_trick_snack = SwitchSettingCard(icon=FluentIcon.GAME, title='自动合成零食（消耗全部材料）')
+        group.addSettingCard(self.synthesize_trick_snack)
+
         return group
 
     def on_interface_shown(self) -> None:
@@ -62,3 +65,4 @@ class SrOdSettingInterface(VerticalScrollInterface):
 
         self.route_yll6_xzq_opt.init_with_adapter(self.ctx.trick_snack_config.get_prop_adapter('route_yll6_xzq'))
         self.route_xzlf_xchzs_opt.init_with_adapter(self.ctx.trick_snack_config.get_prop_adapter('route_xzlf_xchzs'))
+        self.synthesize_trick_snack.init_with_adapter(self.ctx.trick_snack_config.get_prop_adapter('synthesize_trick_snack'))


### PR DESCRIPTION
个人喜欢留一部分不完全用掉，想起来了自己点一下合成。
考虑到探索时可能会有需要使用或递交这些材料的情况（如翁法罗斯的活火）
在奇巧零食的group里面添加了一个选项，可自选是否自动合成
