### PR TITLE
增加路线「云端遗堡」晨昏之眼 4条

### DIFF
--- a/config/world_patrol/P05_WFLS/P05_WFLS_R13_YDYBCHZY_R01_XYGC_1.yml
+++ b/config/world_patrol/P05_WFLS/P05_WFLS_R13_YDYBCHZY_R01_XYGC_1.yml
@@ -1,0 +1,109 @@
+author: ['DoctorReid']
+planet: '翁法罗斯'
+region: '「云端遗堡」晨昏之眼'
+floor: 4
+tp: '悬夜骨城'
+route:
+  - idx: 1
+    op: 'move'
+    data: [1385, 1396]
+  - idx: 2
+    op: 'disposable'
+  - idx: 3
+    op: 'move'
+    data: [1323, 1354]
+  - idx: 4
+    op: 'slow_move'
+    data: [1323, 1322]
+  - idx: 5
+    op: 'move'
+    data: [1347, 1228]
+  - idx: 6
+    op: 'disposable'
+  - idx: 7
+    op: 'move'
+    data: [1348, 1263]
+  - idx: 8
+    op: 'move'
+    data: [1421, 1264]
+  - idx: 9
+    op: 'patrol'
+  - idx: 10
+    op: 'move'
+    data: [1292, 1265]
+  - idx: 11
+    op: 'wait'
+    data: ['seconds', '3']
+  - idx: 12
+    op: 'move'
+    data: [1222, 1266]
+  - idx: 13
+    op: 'disposable'
+  - idx: 14
+    op: 'move'
+    data: [1232, 1318]
+  - idx: 15
+    op: 'disposable'
+  - idx: 16
+    op: 'move'
+    data: [1186, 1368]
+  - idx: 17
+    op: 'disposable'
+  - idx: 18
+    op: 'move'
+    data: [1124, 1357]
+  - idx: 19
+    op: 'wait'
+    data: ['seconds', '3']
+  - idx: 20
+    op: 'move'
+    data: [1042, 1373]
+  - idx: 21
+    op: 'disposable'
+  - idx: 22
+    op: 'move'
+    data: [1060, 1311]
+  - idx: 23
+    op: 'disposable'
+  - idx: 24
+    op: 'move'
+    data: [1047, 1259]
+  - idx: 25
+    op: 'disposable'
+  - idx: 26
+    op: 'move'
+    data: [1061, 1172]
+  - idx: 27
+    op: 'disposable'
+  - idx: 28
+    op: 'move'
+    data: [972, 1177]
+  - idx: 29
+    op: 'move'
+    data: [828, 1174]
+  - idx: 30
+    op: 'move'
+    data: [823, 1102]
+  - idx: 31
+    op: 'patrol'
+  - idx: 32
+    op: 'move'
+    data: [843, 1082]
+  - idx: 33
+    op: 'disposable'
+  - idx: 34
+    op: 'move'
+    data: [828, 1171]
+  - idx: 35
+    op: 'move'
+    data: [911, 1175]
+  - idx: 36
+    op: 'move'
+    data: [908, 1265]
+  - idx: 37
+    op: 'disposable'
+  - idx: 38
+    op: 'move'
+    data: [992, 1271]
+  - idx: 39
+    op: 'patrol'

--- a/config/world_patrol/P05_WFLS/P05_WFLS_R13_YDYBCHZY_R02_XYGC_2.yml
+++ b/config/world_patrol/P05_WFLS/P05_WFLS_R13_YDYBCHZY_R02_XYGC_2.yml
@@ -1,0 +1,96 @@
+author: ['DoctorReid']
+planet: '翁法罗斯'
+region: '「云端遗堡」晨昏之眼'
+floor: 4
+tp: '悬夜骨城'
+route:
+  - idx: 1
+    op: 'move'
+    data: [1423, 1546]
+  - idx: 2
+    op: 'disposable'
+  - idx: 3
+    op: 'move'
+    data: [1422, 1525]
+  - idx: 4
+    op: 'move'
+    data: [1387, 1526]
+  - idx: 5
+    op: 'wait'
+    data: ['seconds', '3']
+  - idx: 6
+    op: 'move'
+    data: [1199, 1528]
+  - idx: 7
+    op: 'wait'
+    data: ['seconds', '3']
+  - idx: 8
+    op: 'move'
+    data: [1113, 1528]
+  - idx: 9
+    op: 'move'
+    data: [1113, 1512]
+  - idx: 10
+    op: 'patrol'
+  - idx: 11
+    op: 'move'
+    data: [1133, 1549]
+  - idx: 12
+    op: 'disposable'
+  - idx: 13
+    op: 'move'
+    data: [1086, 1549]
+  - idx: 14
+    op: 'disposable'
+  - idx: 15
+    op: 'move'
+    data: [1083, 1526]
+  - idx: 16
+    op: 'move'
+    data: [976, 1529]
+  - idx: 17
+    op: 'move'
+    data: [963, 1620]
+  - idx: 18
+    op: 'disposable'
+  - idx: 19
+    op: 'slow_move'
+    data: [910, 1603]
+  - idx: 20
+    op: 'interact'
+    data: '跨入密径'
+  - idx: 21
+    op: 'wait'
+    data: ['seconds', '7']
+  - idx: 22
+    op: 'gameplay_interact'
+    data: ['1']
+  - idx: 23
+    op: 'wait'
+    data: ['in_world', '4']
+  - idx: 24
+    op: 'update_pos'
+    data: [831, 1675, 3]
+  - idx: 25
+    op: 'move'
+    data: [816, 1746]
+  - idx: 26
+    op: 'disposable'
+  - idx: 27
+    op: 'disposable'
+  - idx: 28
+    op: 'move'
+    data: [826, 1709]
+  - idx: 29
+    op: 'move'
+    data: [935, 1707]
+  - idx: 30
+    op: 'move'
+    data: [977, 1657]
+  - idx: 31
+    op: 'patrol'
+  - idx: 32
+    op: 'move'
+    data: [970, 1603]
+  - idx: 33
+    op: 'patrol'

--- a/config/world_patrol/P05_WFLS/P05_WFLS_R13_YDYBCHZY_R03_YBCJ_1.yml
+++ b/config/world_patrol/P05_WFLS/P05_WFLS_R13_YDYBCHZY_R03_YBCJ_1.yml
@@ -1,0 +1,59 @@
+author: ['DoctorReid']
+planet: '翁法罗斯'
+region: '「云端遗堡」晨昏之眼'
+floor: 4
+tp: '遗堡垂井'
+route:
+  - idx: 1
+    op: 'move'
+    data: [2449, 1360]
+  - idx: 2
+    op: 'interact'
+    data: '操作浮台'
+  - idx: 3
+    op: 'wait'
+    data: ['seconds', '12']
+  - idx: 4
+    op: 'slow_move'
+    data: [2470, 1362]
+  - idx: 5
+    op: 'move'
+    data: [2473, 1394]
+  - idx: 6
+    op: 'disposable'
+  - idx: 7
+    op: 'slow_move'
+    data: [2471, 1360]
+  - idx: 8
+    op: 'interact'
+    data: '下降'
+  - idx: 9
+    op: 'wait'
+    data: ['seconds', '12']
+  - idx: 10
+    op: 'update_pos'
+    data: [2471, 1360, 3]
+  - idx: 11
+    op: 'move'
+    data: [2471, 1388]
+  - idx: 12
+    op: 'move'
+    data: [2440, 1394]
+  - idx: 13
+    op: 'move'
+    data: [2429, 1456]
+  - idx: 14
+    op: 'disposable'
+  - idx: 15
+    op: 'move'
+    data: [2440, 1419]
+  - idx: 16
+    op: 'move'
+    data: [2435, 1336]
+  - idx: 17
+    op: 'patrol'
+  - idx: 18
+    op: 'move'
+    data: [2492, 1329]
+  - idx: 19
+    op: 'disposable'

--- a/config/world_patrol/P05_WFLS/P05_WFLS_R13_YDYBCHZY_R04_RJXT_1.yml
+++ b/config/world_patrol/P05_WFLS/P05_WFLS_R13_YDYBCHZY_R04_RJXT_1.yml
@@ -1,0 +1,29 @@
+author: ['DoctorReid']
+planet: '翁法罗斯'
+region: '「云端遗堡」晨昏之眼'
+floor: 2
+tp: '熔金悬台'
+route:
+  - idx: 1
+    op: 'move'
+    data: [2056, 1535]
+  - idx: 2
+    op: 'disposable'
+  - idx: 3
+    op: 'move'
+    data: [2051, 1515]
+  - idx: 4
+    op: 'move'
+    data: [2102, 1427]
+  - idx: 5
+    op: 'patrol'
+  - idx: 6
+    op: 'move'
+    data: [2130, 1409]
+  - idx: 7
+    op: 'disposable'
+  - idx: 8
+    op: 'move'
+    data: [2110, 1473]
+  - idx: 9
+    op: 'disposable'


### PR DESCRIPTION
暂没有涵盖彩虹桥浮台的怪物和熔金悬台下方需要反复通过雅努斯密径才能抵达的怪物。
