### PR TITLE
fix:pr/520中如果用户创建了两个相同的体力计划, 则会死循环；fix:双倍遗器+自动分解4星遗器时挑战成功框识别失败

### DIFF
--- a/assets/game_data/screen_info/battle.yml
+++ b/assets/game_data/screen_info/battle.yml
@@ -57,6 +57,17 @@ area_list:
   template_sub_dir: ''
   template_id: ''
   template_match_threshold: 0.7
+- area_name: 挑战成功-遗器自动分解的双倍奖励
+  pc_rect:
+  - 820
+  - 160
+  - 1100
+  - 240
+  text: 挑战成功
+  lcs_percent: 0.5
+  template_sub_dir: ''
+  template_id: ''
+  template_match_threshold: 0.7
 - area_name: 挑战成功-无奖励
   pc_rect:
   - 820

--- a/src/sr_od/app/trailblaze_power/trailblaze_power_app.py
+++ b/src/sr_od/app/trailblaze_power/trailblaze_power_app.py
@@ -68,7 +68,7 @@ class TrailblazePowerApp(SrApplication):
     def execute_plan(self) -> OperationRoundResult:
         self.ctx.power_config.check_plan_run_times()
         plan: Optional[TrailblazePowerPlanItem] = self.ctx.power_config.get_next_plan()
-        while True:
+        for _ in range(100):
             if plan is None:
                 return self.round_success(TrailblazePowerApp.STATUS_NO_PLAN)
 

--- a/src/sr_od/app/trailblaze_power/trailblaze_power_config.py
+++ b/src/sr_od/app/trailblaze_power/trailblaze_power_config.py
@@ -207,8 +207,8 @@ class TrailblazePowerConfig(YamlConfig):
         if x is None or y is None:
             return False
 
-        # 直接比较ID
-        return x.mission_id == y.mission_id
+        # 比较ID, 运行次数, 计划次数
+        return (x.mission_id == y.mission_id) and (x.plan_times == y.plan_times) and (x.run_times == y.run_times)
 
     def get_next_plan(self, last_tried_plan: Optional[TrailblazePowerPlanItem] = None) -> Optional[
         TrailblazePowerPlanItem]:
@@ -218,14 +218,18 @@ class TrailblazePowerConfig(YamlConfig):
         如果未提供，则从列表的开头查找第一个未完成任务。
         不再在此方法内调用 reset_plans，重置逻辑由调用方（ChargePlanApp）管理。
         """
-        if len(self.plan_list) == 0:
+        len_plan_list = len(self.plan_list)
+        if len_plan_list == 0:
             return None
 
         start_index = 0
         if last_tried_plan is not None:
             # 1. 从上次尝试的计划之后开始查找
+            # 倒序查找避免用户配置两个相同关卡后循环查找到前一个关卡从而无法达到计划末尾
             last_tried_index = -1
-            for i, plan in enumerate(self.plan_list):
+            for j in range(len_plan_list):
+                i = len_plan_list - 1 - j
+                plan = self.plan_list[i]
                 if self._is_same_plan(plan, last_tried_plan):
                     last_tried_index = i
                     break

--- a/src/sr_od/screen_state/battle_screen_state.py
+++ b/src/sr_od/screen_state/battle_screen_state.py
@@ -52,6 +52,7 @@ def get_tp_battle_screen_state(
             '挑战成功-有奖励',
             '挑战成功-双倍奖励',
             '挑战成功-无奖励',
+            '挑战成功-遗器自动分解的双倍奖励',
         ]
 
         for area_name in success_area_list:


### PR DESCRIPTION
论我为什么要加两个相同的饰品提取任务

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - 新增对“挑战成功-遗器自动分解的双倍奖励”状态的识别，战斗可正确判定为胜利。

- 重构
  - 执行计划改为单次最多迭代100次，提升稳定性并避免极端情况下的长循环。
  - 优化计划选择与续接逻辑，匹配条件更严格，并在存在重复项时采用反向查找以更准确定位上次尝试的计划。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->