### PR TITLE
新版本的副本挑战次数

### DIFF
--- a/assets/game_data/screen_info/calyx.yml
+++ b/assets/game_data/screen_info/calyx.yml
@@ -1,14 +1,28 @@
 screen_id: calyx
-screen_name: 拟造花萼
+screen_name: 副本连续挑战次数
 pc_alt: false
 area_list:
-- area_name: 文本-挑战次数
+- area_name: 文本-挑战次数-饰品提取
   id_mark: false
   pc_rect:
-  - 1576
-  - 826
-  - 1616
-  - 866
+  - 1688
+  - 850
+  - 1730
+  - 888
+  text: ''
+  lcs_percent: 0.5
+  template_sub_dir: ''
+  template_id: ''
+  template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
+- area_name: 文本-挑战次数-其他
+  id_mark: false
+  pc_rect:
+  - 1565
+  - 846
+  - 1630
+  - 886
   text: ''
   lcs_percent: 0.5
   template_sub_dir: ''

--- a/assets/game_data/screen_info/challenge_mission.yml
+++ b/assets/game_data/screen_info/challenge_mission.yml
@@ -2,7 +2,35 @@ screen_id: challenge_mission
 screen_name: 挑战副本
 pc_alt: false
 area_list:
-- area_name: 次数加
+- area_name: 次数加-饰品提取
+  id_mark: false
+  pc_rect:
+  - 1800
+  - 860
+  - 1900
+  - 940
+  text: ''
+  lcs_percent: 0.5
+  template_sub_dir: challenge_mission
+  template_id: battle_times_plus
+  template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
+- area_name: 次数减-饰品提取
+  id_mark: false
+  pc_rect:
+  - 1400
+  - 860
+  - 1550
+  - 940
+  text: ''
+  lcs_percent: 0.5
+  template_sub_dir: challenge_mission
+  template_id: battle_times_minus
+  template_match_threshold: 0.7
+  color_range: null
+  goto_list: []
+- area_name: 次数加-其他
   id_mark: false
   pc_rect:
   - 1800
@@ -16,7 +44,7 @@ area_list:
   template_match_threshold: 0.7
   color_range: null
   goto_list: []
-- area_name: 次数减
+- area_name: 次数减-其他
   id_mark: false
   pc_rect:
   - 1190

--- a/assets/game_data/screen_info/ornamenet_extraction.yml
+++ b/assets/game_data/screen_info/ornamenet_extraction.yml
@@ -103,10 +103,10 @@ area_list:
   template_match_threshold: 0.7
 - area_name: 按钮-支援
   pc_rect:
-  - 1067
-  - 812
-  - 1120
-  - 838
+  - 927
+  - 870
+  - 1050
+  - 928
   text: 支援
   lcs_percent: 0.5
   template_sub_dir: ''

--- a/src/sr_od/app/div_uni/operations/ornamenet_extraction.py
+++ b/src/sr_od/app/div_uni/operations/ornamenet_extraction.py
@@ -4,9 +4,11 @@ from one_dragon.base.operation.operation_edge import node_from
 from one_dragon.base.operation.operation_node import operation_node
 from one_dragon.base.operation.operation_round_result import OperationRoundResult
 from one_dragon.utils.i18_utils import gt
+from one_dragon.utils.log_utils import log
 from sr_od.app.div_uni.operations.choose_oe_file import ChooseOeFile
 from sr_od.app.div_uni.operations.choose_oe_support import ChooseOeSupport
 from sr_od.app.sim_uni.operations.move_v1.sim_uni_move_to_enemy_by_mm import SimUniMoveToEnemyByMiniMap
+from sr_od.challenge_mission.choose_challenge_times import ChooseChallengeTimes
 from sr_od.context.sr_context import SrContext
 from sr_od.interastral_peace_guide.guide_def import GuideMission
 from sr_od.interastral_peace_guide.guide_transport import GuideTransport
@@ -96,11 +98,12 @@ class ChallengeOrnamentExtraction(SrOperation):
     #
     #     return self.round_success()
 
-    @node_from(from_name='传送')
-    @operation_node(name='选择存档')
-    def choose_file(self) -> OperationRoundResult:
-        op = ChooseOeFile(self.ctx, self.file_num)
-        return self.round_by_op_result(op.execute())
+    # todo 这个函数是不是没用
+    # @node_from(from_name='传送')
+    # @operation_node(name='选择存档')
+    # def choose_file(self) -> OperationRoundResult:
+    #     op = ChooseOeFile(self.ctx, self.file_num)
+    #     return self.round_by_op_result(op.execute())
 
     @node_from(from_name='传送')
     @operation_node(name='选择支援')
@@ -110,6 +113,16 @@ class ChallengeOrnamentExtraction(SrOperation):
 
     @node_from(from_name='选择支援')
     @node_from(from_name='选择支援', success=False)
+    @operation_node(name='选择挑战次数')
+    def click_challenge_times(self) -> OperationRoundResult:
+        log.info('本次挑战次数 %d', self.run_times)
+        if self.run_times > 1:
+            op = ChooseChallengeTimes(self.ctx, min(6, self.run_times), mission_type='饰品提取')
+            return self.round_by_op_result(op.execute())
+        else:
+            return self.round_success()
+
+    @node_from(from_name='选择挑战次数')
     @operation_node(name='点击挑战')
     def click_challenge(self) -> OperationRoundResult:
         """

--- a/src/sr_od/app/trailblaze_power/trailblaze_power_app.py
+++ b/src/sr_od/app/trailblaze_power/trailblaze_power_app.py
@@ -101,11 +101,7 @@ class TrailblazePowerApp(SrApplication):
         self.ctx.sim_uni_record.check_and_update_status()
         self.last_mission = mission
 
-        if mission.cate.cn not in ['模拟宇宙', '饰品提取']:
-            op = UseTrailblazePower(self.ctx, mission, plan.team_num, run_times,
-                                    support=plan.support if plan.support != 'none' else None,
-                                    on_battle_success=self._on_normal_task_success)
-        elif mission.cate.cn == '模拟宇宙':
+        if mission.cate.cn == '模拟宇宙':
             sim_num = 0
             for i in SimUniWorldEnum:
                 if i.value.name == mission.mission_name:
@@ -130,7 +126,9 @@ class TrailblazePowerApp(SrApplication):
                                              support_character=plan.support if plan.support != 'none' else None,
                                              get_reward_callback=self.on_oe_get_reward)
         else:
-            return self.round_fail('未知副本类型')
+            op = UseTrailblazePower(self.ctx, mission, plan.team_num, run_times,
+                                    support=plan.support if plan.support != 'none' else None,
+                                    on_battle_success=self._on_normal_task_success)
 
         return self.round_by_op_result(op.execute())
 

--- a/src/sr_od/challenge_mission/choose_challenge_times.py
+++ b/src/sr_od/challenge_mission/choose_challenge_times.py
@@ -14,15 +14,17 @@ from sr_od.operations.sr_operation import SrOperation
 
 class ChooseChallengeTimes(SrOperation):
 
-    def __init__(self, ctx: SrContext, total_times: int):
+    def __init__(self, ctx: SrContext, total_times: int, mission_type: str):
         """
         在挑战副本的选择难度页面
         选择挑战次数
         :param ctx:
         :param total_times: 总共挑战次数 <=6
+        :param mission_type 挑战类型, 饰品提取/其他
         """
         SrOperation.__init__(self, ctx, op_name=gt('选择挑战次数'))
         self.total_times: int = total_times
+        self.mission_type = mission_type
 
     @operation_node(name='选择', node_max_retry_times=5, is_start_node=True)
     def choose(self) -> OperationRoundResult:
@@ -38,7 +40,7 @@ class ChooseChallengeTimes(SrOperation):
             if self._click_plus(screen, self.total_times - current):
                 return self.round_success()
         else:
-            if self._click_minus(screen, self.total_times - current):
+            if self._click_minus(screen, current - self.total_times):
                 return self.round_success()
 
         return self.round_retry('未能判断当前选择次数', wait=1)
@@ -49,9 +51,10 @@ class ChooseChallengeTimes(SrOperation):
         :param screen: 屏幕截图
         :return: 当前选择次数
         """
-        area = self.ctx.screen_loader.get_area('拟造花萼', '文本-挑战次数')
+        area = self.ctx.screen_loader.get_area('副本连续挑战次数', '文本-挑战次数-' + self.mission_type)
         part = cv2_utils.crop_image_only(screen, area.rect)
         # cv2_utils.show_image(part, win_name='_get_current_times')
+        # cv2.imwrite('y:/part.png', part)
         ocr_result = self.ctx.ocr.run_ocr_single_line(part, strict_one_line=True)
         return str_utils.get_positive_digits(ocr_result, err=0)
 
@@ -62,8 +65,8 @@ class ChooseChallengeTimes(SrOperation):
         :param click_times: 需要点击的次数
         :return: 是否点击成功
         """
-        area = self.ctx.screen_loader.get_area('挑战副本', '次数加')
-        result = self.round_by_find_area(screen, '挑战副本', '次数加')
+        area = self.ctx.screen_loader.get_area('挑战副本', '次数加-' + self.mission_type)
+        result = self.round_by_find_area(screen, '挑战副本', '次数加-' + self.mission_type)
 
         if not result.is_success:
             return False
@@ -83,8 +86,8 @@ class ChooseChallengeTimes(SrOperation):
         :param click_times: 需要点击的次数
         :return: 是否点击成功
         """
-        area = self.ctx.screen_loader.get_area('挑战副本', '次数减')
-        result = self.round_by_find_area(screen, '挑战副本', '次数减')
+        area = self.ctx.screen_loader.get_area('挑战副本', '次数减-' + self.mission_type)
+        result = self.round_by_find_area(screen, '挑战副本', '次数减-' + self.mission_type)
 
         if not result.is_success:
             return False

--- a/src/sr_od/challenge_mission/use_trailblaze_power.py
+++ b/src/sr_od/challenge_mission/use_trailblaze_power.py
@@ -75,7 +75,7 @@ class UseTrailblazePower(SrOperation):
         self.current_challenge_times = self._get_current_challenge_times()
         log.info('本次挑战次数 %d', self.current_challenge_times)
         if self.current_challenge_times > 1:
-            op = ChooseChallengeTimes(self.ctx, self.current_challenge_times)
+            op = ChooseChallengeTimes(self.ctx, self.current_challenge_times, mission_type='其他')
             return self.round_by_op_result(op.execute())
         else:
             return self.round_success()
@@ -85,13 +85,16 @@ class UseTrailblazePower(SrOperation):
         获取当前的挑战次数
         :return:
         """
+        current_challenge_times = self.plan_times - self.finish_times
         if self.mission.cate.cn in ['拟造花萼（金）', '拟造花萼（赤）']:
-            current_challenge_times = self.plan_times - self.finish_times
-            if current_challenge_times > 6:
-                current_challenge_times = 6
-            return current_challenge_times
-        else:
-            return 1
+            return min(24, current_challenge_times)
+        elif self.mission.cate.cn == '凝滞虚影':
+            return min(8, current_challenge_times)
+        elif self.mission.cate.cn == '侵蚀隧洞':
+            return min(6, current_challenge_times)
+        # elif self.mission.cate.cn == '饰品提取':
+        #     return min(6, current_challenge_times)
+        return 1
 
     @node_from(from_name='选择次数')
     @operation_node(name='点击挑战')


### PR DESCRIPTION
适配一次刷240体力

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 增加了饰品提取挑战的挑战次数选择功能。

* **错误修复**
  * 调整了支援按钮的检测区域位置，改进了界面识别准确性。

* **优化**
  * 优化了不同任务类型的挑战次数处理逻辑，不同任务类别现在具有专门的次数上限设置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->