### PR TITLE
修改培养目标的挑战次数, 使其一次能连续刷6遍本

### DIFF
--- a/assets/game_data/interastral_peace_guide_data.yml
+++ b/assets/game_data/interastral_peace_guide_data.yml
@@ -11,7 +11,7 @@
         - mission_name: "培养目标"
           show_in_power_plan: true
           display_name: "培养目标"
-          power: 20
+          power: 40
 
     - category_name: "饰品提取"
       remark_in_game: "位面饰品"

--- a/src/sr_od/challenge_mission/use_trailblaze_power.py
+++ b/src/sr_od/challenge_mission/use_trailblaze_power.py
@@ -90,7 +90,7 @@ class UseTrailblazePower(SrOperation):
             return min(24, current_challenge_times)
         elif self.mission.cate.cn == '凝滞虚影':
             return min(8, current_challenge_times)
-        elif self.mission.cate.cn == '侵蚀隧洞':
+        elif self.mission.cate.cn in ['侵蚀隧洞', '培养目标']:
             return min(6, current_challenge_times)
         return 1
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 更新日志

* **游戏平衡调整**
  * 调整"培养目标"任务的强度值，从20提升至40。
  * 扩展任务时间限制机制，现在"侵蚀隧洞"和"培养目标"任务都将应用6分钟的上限约束。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->