### PR TITLE
培养目标体力使用方式讨论

### DIFF
--- a/src/sr_od/app/trailblaze_power/trailblaze_power_app.py
+++ b/src/sr_od/app/trailblaze_power/trailblaze_power_app.py
@@ -52,6 +52,7 @@ class TrailblazePowerApp(SrApplication):
         return self.round_success(status=TrailblazePowerApp.STATUS_WITH_PLAN)
 
     @node_from(from_name='检查当前需要挑战的关卡', status=STATUS_WITH_PLAN)
+    @node_from(from_name='执行开拓力计划')
     @operation_node(name='打开指南检查体力')
     def open_guide(self) -> OperationRoundResult:
         op = GuideCheckPower(self.ctx)
@@ -63,7 +64,6 @@ class TrailblazePowerApp(SrApplication):
         return self.round_by_op_result(op_result)
 
     @node_from(from_name='打开指南检查体力')
-    @node_from(from_name='执行开拓力计划')
     @operation_node(name='执行开拓力计划')
     def execute_plan(self) -> OperationRoundResult:
         self.ctx.power_config.check_plan_run_times()
@@ -86,6 +86,7 @@ class TrailblazePowerApp(SrApplication):
             if plan is None:
                 break
 
+        # noinspection PyUnboundLocalVariable
         if can_run_times == 0:
             return self.round_success(TrailblazePowerApp.STATUS_NO_ENOUGH_POWER)
 


### PR DESCRIPTION
目前main的状况是先识别体力然后按顺序打体力，和培养计划结合后会带来几个问题：

1. 培养目标体力设置为40以下时，有可能因为角色已经培养完毕、只需要刷遗器，从而导致体力一点都用不出去
2. 培养目标体力设置为40时，有可能因为角色需要刷技能书，从而导致240体力只刷6次技能书然后下号

此pr目前修改为每次打体力之后识别一次体力计划，从而使得每日打培养目标时, 能够一直打体力直到剩余体力<30。但是这个方案不优雅：如果上号时240体力刷技能书那就是依次刷6、4、3、2、2、1、1、1、1次，此时剩余体力为30。我目前想到的其他几个方案是：

1. 识别培养目标的刷本方式然后推算出每次使用的体力；
2. 通过识别最大连续刷本次数来推算出此本所需体力。

但是这两个方案代码改动量比较多而且可能随着游戏版本更新而失效，从而可能导致体力没刷满120，每日领不了。有没有其他合适的方案 @kawayiYokami 