### PR TITLE
[codex] 手动停止时可跳过收尾动作

### DIFF
--- a/src/one_dragon/base/config/one_dragon_config.py
+++ b/src/one_dragon/base/config/one_dragon_config.py
@@ -188,3 +188,11 @@ class OneDragonConfig(YamlConfig):
     @after_done.setter
     def after_done(self, new_value: str):
         self.update('after_done', new_value)
+
+    @property
+    def skip_after_done_when_manual_stop(self) -> bool:
+        return self.get('skip_after_done_when_manual_stop', False)
+
+    @skip_after_done_when_manual_stop.setter
+    def skip_after_done_when_manual_stop(self, new_value: bool):
+        self.update('skip_after_done_when_manual_stop', new_value)

--- a/src/one_dragon/base/operation/application/application_run_context.py
+++ b/src/one_dragon/base/operation/application/application_run_context.py
@@ -86,6 +86,7 @@ class ApplicationRunContext:
 
         # 通知池，应用开始时清空重用
         self.notify_pool: NotifyPool = NotifyPool()
+        self.manual_stop_requested: bool = False
 
     def registry_application(
         self,
@@ -319,6 +320,7 @@ class ApplicationRunContext:
             return False
 
         if self.ctx.controller.init_before_context_run():
+            self.manual_stop_requested = False
             self._run_state = ApplicationRunContextStateEnum.RUNNING
             self.event_bus.dispatch_event(
                 ApplicationRunContextStateEventEnum.START, self._run_state
@@ -327,7 +329,7 @@ class ApplicationRunContext:
         else:
             return False
 
-    def stop_running(self):
+    def stop_running(self, manual: bool = False):
         """
         停止运行。
 
@@ -335,6 +337,8 @@ class ApplicationRunContext:
         """
         if self.is_context_stop:
             return
+        if manual:
+            self.manual_stop_requested = True
         if self.is_context_running:  # 先触发暂停 让执行中的指令停止
             self.switch_context_pause_and_run()
         self._run_state = ApplicationRunContextStateEnum.STOP

--- a/src/one_dragon/base/operation/one_dragon_context.py
+++ b/src/one_dragon/base/operation/one_dragon_context.py
@@ -321,7 +321,7 @@ class OneDragonContext(ContextEventBus, OneDragonEnvContext):
         if key == self.key_start_running:
             self.run_context.switch_context_pause_and_run()
         elif key == self.key_stop_running:
-            self.run_context.stop_running()
+            self.run_context.stop_running(manual=True)
         elif key == self.key_screenshot:
             self.screenshot_and_save_debug(self.env_config.copy_screenshot)
 

--- a/src/one_dragon_qt/view/app_run_interface.py
+++ b/src/one_dragon_qt/view/app_run_interface.py
@@ -192,7 +192,7 @@ class AppRunInterface(VerticalScrollInterface):
             self.ctx.run_context.switch_context_pause_and_run()
 
     def _on_stop_clicked(self) -> None:
-        self.ctx.run_context.stop_running()
+        self.ctx.run_context.stop_running(manual=True)
 
 
 class SplitAppRunInterface(AppRunInterface):

--- a/src/one_dragon_qt/view/one_dragon/one_dragon_run_interface.py
+++ b/src/one_dragon_qt/view/one_dragon/one_dragon_run_interface.py
@@ -177,11 +177,30 @@ class OneDragonRunInterface(SplitAppRunInterface):
         SplitAppRunInterface.on_context_state_changed(self)
         self.app_run_list.update_cards_display()
 
-        if self.ctx.run_context.is_context_stop and self.need_after_done_opt:
-            if self.ctx.one_dragon_config.after_done == AfterDoneOpEnum.SHUTDOWN.value.value:
+        if self._should_run_after_done():
+            after_done = self.ctx.one_dragon_config.after_done
+            if after_done == AfterDoneOpEnum.SHUTDOWN.value.value:
                 cmd_utils.shutdown_sys(60)
-            elif self.ctx.one_dragon_config.after_done == AfterDoneOpEnum.CLOSE_GAME.value.value:
+            elif after_done == AfterDoneOpEnum.CLOSE_GAME.value.value:
                 self.ctx.controller.close_game()
+
+    def _should_run_after_done(self) -> bool:
+        if not self.ctx.run_context.is_context_stop or not self.need_after_done_opt:
+            return False
+
+        after_done = self.ctx.one_dragon_config.after_done
+        if (
+            self.ctx.run_context.manual_stop_requested
+            and self.ctx.one_dragon_config.skip_after_done_when_manual_stop
+            and after_done in (
+                AfterDoneOpEnum.SHUTDOWN.value.value,
+                AfterDoneOpEnum.CLOSE_GAME.value.value,
+            )
+        ):
+            log.info('手动停止，跳过结束后关闭游戏或关机')
+            return False
+
+        return True
 
     def _on_app_state_changed(self, event) -> None:
         self.app_run_list.update_cards_display()

--- a/src/one_dragon_qt/view/setting/setting_env_interface.py
+++ b/src/one_dragon_qt/view/setting/setting_env_interface.py
@@ -171,6 +171,13 @@ class SettingEnvInterface(VerticalScrollInterface):
         )
         key_group.addSettingCard(self.key_stop_running_input)
 
+        self.manual_stop_skip_after_done_opt = SwitchSettingCard(
+            icon=FluentIcon.CLOSE,
+            title='手动停止跳过收尾动作',
+            content='开启后，按停止热键或停止按钮手动结束时，不执行一条龙“结束后”里的关闭游戏或关机'
+        )
+        key_group.addSettingCard(self.manual_stop_skip_after_done_opt)
+
         self.key_screenshot_input = KeySettingCard(
             icon=FluentIcon.CAMERA, title='游戏截图', content='用于开发、提交bug。会自动对UID打码，保存在 .debug/images/ 文件夹中'
         )
@@ -196,6 +203,9 @@ class SettingEnvInterface(VerticalScrollInterface):
 
         self.key_start_running_input.init_with_adapter(self.ctx.env_config.get_prop_adapter('key_start_running'))
         self.key_stop_running_input.init_with_adapter(self.ctx.env_config.get_prop_adapter('key_stop_running'))
+        self.manual_stop_skip_after_done_opt.init_with_adapter(
+            self.ctx.one_dragon_config.get_prop_adapter('skip_after_done_when_manual_stop')
+        )
         self.key_screenshot_input.init_with_adapter(self.ctx.env_config.get_prop_adapter('key_screenshot'))
         self.key_debug_input.init_with_adapter(self.ctx.env_config.get_prop_adapter('key_debug'))
 


### PR DESCRIPTION
## 变更内容

- 新增一条龙配置项 `skip_after_done_when_manual_stop`，默认关闭。
- 在设置页“脚本按键”区域新增开关：`手动停止跳过收尾动作`。
- 将 F10 停止和界面停止按钮标记为手动停止。
- 当用户手动停止且该开关开启时，跳过一条龙“结束后”配置中的关闭游戏或关机动作；自然运行结束仍保持原行为。

## 影响

开启该选项后，用户手动用 F10 或停止按钮结束任务时，不会因为“一条龙 -> 结束后”配置而触发关机或关闭游戏。默认关闭，不改变现有用户行为。

## 验证

- `git diff --check`
- 对相关 Python 文件执行 `compile(..., 'exec')` 语法检查
